### PR TITLE
Made the test OS agnostic

### DIFF
--- a/java/src/test/java/com/codurance/training/tasks/ApplicationTest.java
+++ b/java/src/test/java/com/codurance/training/tasks/ApplicationTest.java
@@ -10,6 +10,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static java.lang.System.lineSeparator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -107,7 +108,7 @@ public final class ApplicationTest {
 
     private void readLines(String... expectedOutput) throws IOException {
         for (String line : expectedOutput) {
-            read(line + "\n");
+            read(line + lineSeparator());
         }
     }
 


### PR DESCRIPTION
 Hi Samir, Here is a pull request to solve the issue some people were having if they were using Windows at the last LSCC meetup. I've changed the line endings to be sourced from the system rather than hard coded to \n.
