### PR TITLE
fix typescript tests,

### DIFF
--- a/typescript/tests/application_test.ts
+++ b/typescript/tests/application_test.ts
@@ -26,8 +26,11 @@ class TestCtxt
     constructor(public test: nodeunit.Test){
         var count = 0;
         this.output.on('readable', () => {
-            if(count >= this.expectations.length) {
+            if(count > this.expectations.length) {
                 this.test.ok(false, "Got more output than expected proabably didn't quit")
+                this.test.done();
+            } else if(count == this.expectations.length) {
+                this.test.ok(true);
                 this.test.done();
             } else if(this.expectations[count].test()) {
                 count += 1;


### PR DESCRIPTION
This makes the tests pass in what seems like a satisfactory manner. I make a case for forcing the end of the test other than the output stream 'end' event that isn't raised. 

The tests are a bit surprising in nature, it took me a while to get a hold of the logic in the TestCtxt constructor.

